### PR TITLE
Represent UUID's as strings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ wheel==0.24.0
 
 # MkDocs for documentation previews/deploys
 mkdocs==0.11.1
+six==1.14.0

--- a/rest_framework_yaml/compat.py
+++ b/rest_framework_yaml/compat.py
@@ -3,8 +3,7 @@ The `compat` module provides support for backwards compatibility with older
 versions of django/python, and compatibility wrappers around optional packages.
 """
 # flake8: noqa
-
-from django.utils import six
+import six
 try:
     import yaml
 except ImportError:

--- a/rest_framework_yaml/encoders.py
+++ b/rest_framework_yaml/encoders.py
@@ -6,7 +6,7 @@ import decimal
 import types
 
 from django.utils import six
-
+from uuid import UUID
 from .compat import (
     yaml, yaml_represent_text, Hyperlink, OrderedDict, ReturnDict, ReturnList
 )
@@ -34,8 +34,12 @@ class SafeDumper(yaml.SafeDumper):
             if not isinstance(mapping, OrderedDict):
                 mapping.sort()
         for item_key, item_value in mapping:
+            if isinstance(item_value, UUID):
+                item_value = str(item_value)
+                
             node_key = self.represent_data(item_key)
             node_value = self.represent_data(item_value)
+          
             if not (isinstance(node_key, yaml.ScalarNode) and not node_key.style):
                 best_style = False
             if not (isinstance(node_value, yaml.ScalarNode) and not node_value.style):

--- a/rest_framework_yaml/encoders.py
+++ b/rest_framework_yaml/encoders.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import decimal
 import types
 
-from django.utils import six
+import six
 from uuid import UUID
 from .compat import (
     yaml, yaml_represent_text, Hyperlink, OrderedDict, ReturnDict, ReturnList

--- a/rest_framework_yaml/parsers.py
+++ b/rest_framework_yaml/parsers.py
@@ -4,7 +4,7 @@ Provides YAML parsing support.
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.utils import six
+import six
 from rest_framework.exceptions import ParseError
 from rest_framework.parsers import BaseParser
 


### PR DESCRIPTION
Convert UUID objects to string, otherwise pyyaml will fail to convert.