### PR TITLE
#18 - Gracefully Proceed on Sort Error (TypeError)

### DIFF
--- a/rest_framework_yaml/encoders.py
+++ b/rest_framework_yaml/encoders.py
@@ -39,7 +39,10 @@ class SafeDumper(yaml.SafeDumper):
         if hasattr(mapping, "items"):
             mapping = list(mapping.items())
             if not isinstance(mapping, OrderedDict):
-                mapping.sort()
+                try:
+                    mapping.sort()
+                except TypeError:
+                    pass
         for item_key, item_value in mapping:
             node_key = self.represent_data(item_key)
             node_value = self.represent_data(item_value)

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -55,6 +55,19 @@ class YAMLRendererTests(TestCase):
         )
         self.assertYAMLContains(content.decode("utf-8"), "field: '111.2'")
 
+    def test_render_none_type(self):
+        """
+        Test YAML rendering with None type
+        """
+        _yaml_repr = "foo:\n- bar\n- baz\nnull:\n- null\n"
+
+        obj = {"foo": ["bar", "baz"], None: [None]}
+
+        renderer = YAMLRenderer()
+        content = renderer.render(obj, "application/yaml")
+
+        self.assertEqual(content.decode("utf-8"), _yaml_repr)
+
     @unittest.skipUnless(Hyperlink, "Hyperlink is undefined")
     def test_render_hyperlink(self):
         """


### PR DESCRIPTION
Do not sort if `TypeError` is raised and gracefully proceed. 